### PR TITLE
add csr. and lcsr. words

### DIFF
--- a/src/modules/cell_utils.rs
+++ b/src/modules/cell_utils.rs
@@ -56,7 +56,7 @@ impl CellUtils {
         stack.push_raw(builder)
     }
 
-    #[cmd(name = "ref", stack)]
+    #[cmd(name = "ref,", stack)]
     fn interpret_store_ref(stack: &mut Stack) -> Result<()> {
         let cell = stack.pop_cell()?;
         let mut builder = stack.pop_builder()?;

--- a/src/modules/debug_utils.rs
+++ b/src/modules/debug_utils.rs
@@ -1,5 +1,6 @@
 use crate::core::*;
 use crate::error::*;
+use crate::util::cellslice_ptint_rec;
 
 pub struct DebugUtils;
 
@@ -33,6 +34,23 @@ impl DebugUtils {
     fn interpret_dotbin(ctx: &mut Context, space_after: bool) -> Result<()> {
         let int = ctx.stack.pop_int()?;
         write!(ctx.stdout, "{:b}{}", int.as_ref(), opt_space(space_after))?;
+        Ok(())
+    }
+
+    #[cmd(name = "csr.", args(pop_limit = false))]
+    #[cmd(name = "lcsr.", args(pop_limit = true))]
+    fn interpret_dot_cellslice_rec(ctx: &mut Context, pop_limit: bool) -> Result<()> {
+        const DEFAULT_RECURSIVE_PRINT_LIMIT: u16 = 100;
+
+        let limit = if pop_limit {
+            ctx.stack.pop_smallint_range(0, u16::MAX.into())? as u16
+        } else {
+            DEFAULT_RECURSIVE_PRINT_LIMIT
+        };
+
+        let cs = ctx.stack.pop()?;
+        cellslice_ptint_rec(ctx.stdout, cs.as_slice()?, 0, limit)?;
+
         Ok(())
     }
 


### PR DESCRIPTION
Added new words, that allows to print slices from the stack, i.e. `csr.` word identical to the C++ implementation of Fift, and new `lcsr.` word, which allows retrieving the limit of recursive output from the stack. 

New words:
- `csr.` (s – )
- `lcsr.` (s i – )

<img width="521" alt="image" src="https://github.com/broxus/fift/assets/46900925/c2e41570-179f-4cfe-9ee7-23bb0a576112">
<img width="570" alt="image" src="https://github.com/broxus/fift/assets/46900925/12d6effb-b81a-45d3-9171-572018037d1a">
