### PR TITLE
add join tuple words & fixes

### DIFF
--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -163,6 +163,28 @@ impl FiftModule for BaseModule {
         stack.push_raw(tuple)
     }
 
+    #[cmd(name = "[]>$", stack, args(pop_sep = false))] //  []>$   (t[S0, S1, ..., Sn]   -- S)
+    #[cmd(name = "[]>$by", stack, args(pop_sep = true))] // []>$by (t[S0, S1, ..., Sn] s -- S)
+    fn interpret_tuple_strings_join(stack: &mut Stack, pop_sep: bool) -> Result<()> {
+        let sep = if pop_sep {
+            stack.pop_string()?.to_string()
+        } else {
+            "".to_string()
+        };
+
+        let mut result = String::new();
+        let tuple = stack.pop_tuple()?.to_vec();
+        for (i, e) in tuple.iter().enumerate() {
+            result.push_str(e.as_string()?);
+
+            if i < tuple.len() - 1 {
+                result.push_str(&sep);
+            }
+        }
+
+        stack.push(result)
+    }
+
     #[cmd(name = "count", stack)]
     fn interpret_tuple_len(stack: &mut Stack) -> Result<()> {
         let len = stack.pop_tuple()?.len();

--- a/src/modules/string_utils.rs
+++ b/src/modules/string_utils.rs
@@ -218,10 +218,15 @@ impl StringUtils {
         let sep = stack.pop_string()?;
         let string = stack.pop_string()?;
 
-        let substrings = string
+        let mut substrings = string
             .split(sep.as_str())
             .map(|s| Box::new(s.to_string()) as Box<dyn StackValue>)
             .collect::<Vec<_>>();
+
+        if sep.is_empty() {
+            substrings.remove(0);
+            substrings.pop();
+        }
 
         stack.push(substrings)
     }


### PR DESCRIPTION
Add new words:
- `[]>$ (t[S0, S1, ..., Sn] -- S)`
- `[]>$by (t[S0, S1, ..., Sn] s -- S)`

Fixes:
- fix `$sep` behavior about empty string separator