### PR TITLE
new tuple words: []popn, []pop, []len

### DIFF
--- a/libs/src/Fift.fif
+++ b/libs/src/Fift.fif
@@ -124,6 +124,9 @@ variable base
 { "" swap { 0 word 2dup $cmp } { rot swap $+ +cr swap } while 2drop } : scan-until-word
 { 0 word -trailing scan-until-word 1 'nop } ::_ $<<
 
+{ count } : []len
+{ tpop } : []pop
+
 /* UNIMPLEMENTED
 { 0x40 runvmx } : runvmcode
 { 0x48 runvmx } : gasrunvmcode

--- a/src/core/stack.rs
+++ b/src/core/stack.rs
@@ -83,6 +83,18 @@ impl Stack {
         Ok(())
     }
 
+    pub fn extend_raw<T>(&mut self, items: T) -> Result<()>
+    where
+        T: IntoIterator,
+        T::Item: Into<Rc<dyn StackValue>>,
+    {
+        for item in items {
+            self.push_raw(item.into())?;
+        }
+
+        Ok(())
+    }
+
     pub fn push_null(&mut self) -> Result<()> {
         self.push_raw(Self::make_null())
     }

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -148,6 +148,19 @@ impl FiftModule for BaseModule {
         stack.push_raw(last)
     }
 
+    #[cmd(name = "[]popn", stack)]
+    fn interpret_tuple_popn(stack: &mut Stack) -> Result<()> {
+        let n = stack.pop_usize()?;
+        let mut tuple = stack.pop_tuple()?;
+
+        let moved: Vec<_> = (0..n)
+            .map(|_| Rc::make_mut(&mut tuple).pop().context("Tuple underflow"))
+            .collect::<Result<_>>()?;
+
+        stack.push_raw(tuple)?;
+        stack.extend_raw(moved.iter().rev().cloned())
+    }
+
     #[cmd(name = "[]", stack)]
     fn interpret_tuple_index(stack: &mut Stack) -> Result<()> {
         let idx = stack.pop_usize()?;


### PR DESCRIPTION
New words:
- `[]popn ( t i -- t' ... )`
<img width="268" alt="image" src="https://github.com/broxus/fift/assets/46900925/a25436eb-e69a-4bf1-9c56-2b8d50d5c353">

New useful aliases in `Fift.fif`:
- `[]len` -> `count` 

<img width="256" alt="image" src="https://github.com/broxus/fift/assets/46900925/354c16fd-7d2b-4300-a0c8-f378c0cfa831">

- `[]pop` -> `tpop` 

<img width="244" alt="image" src="https://github.com/broxus/fift/assets/46900925/8e570fd6-8d37-4594-9925-e521093a773a">
